### PR TITLE
Fixed potential leaks and project compile error.

### DIFF
--- a/FHSTwitterEngine.xcodeproj/project.pbxproj
+++ b/FHSTwitterEngine.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		21D6642416E78494008E0337 /* Base64TranscoderFHS.c in Sources */ = {isa = PBXBuildFile; fileRef = 21D6642216E78467008E0337 /* Base64TranscoderFHS.c */; };
 		9B2A1BC415E805D1007E66E0 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 9B2A1B9915E805D1007E66E0 /* AppDelegate.m */; };
 		9B2A1BC515E805D1007E66E0 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 9B2A1B9A15E805D1007E66E0 /* InfoPlist.strings */; };
 		9B2A1BC615E805D1007E66E0 /* ViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9B2A1B9C15E805D1007E66E0 /* ViewController.xib */; };
@@ -14,7 +15,6 @@
 		9B2A1BD715E805D1007E66E0 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 9B2A1BC315E805D1007E66E0 /* ViewController.m */; };
 		9B2A1C2915E807D9007E66E0 /* FHSTwitterEngine.m in Sources */ = {isa = PBXBuildFile; fileRef = 9B2A1C0915E807D9007E66E0 /* FHSTwitterEngine.m */; };
 		9B2A1C2B15E807D9007E66E0 /* NSString+URLEncoding.m in Sources */ = {isa = PBXBuildFile; fileRef = 9B2A1C0F15E807D9007E66E0 /* NSString+URLEncoding.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		9B2A1C2D15E807D9007E66E0 /* Base64Transcoder.c in Sources */ = {isa = PBXBuildFile; fileRef = 9B2A1C1315E807D9007E66E0 /* Base64Transcoder.c */; };
 		9B2A1C2E15E807D9007E66E0 /* OAAsynchronousDataFetcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 9B2A1C1615E807D9007E66E0 /* OAAsynchronousDataFetcher.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		9B2A1C2F15E807D9007E66E0 /* OAConsumer.m in Sources */ = {isa = PBXBuildFile; fileRef = 9B2A1C1815E807D9007E66E0 /* OAConsumer.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		9B2A1C3115E807D9007E66E0 /* OAHMAC_SHA1SignatureProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 9B2A1C1C15E807D9007E66E0 /* OAHMAC_SHA1SignatureProvider.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
@@ -30,6 +30,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		21D6642216E78467008E0337 /* Base64TranscoderFHS.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = Base64TranscoderFHS.c; sourceTree = "<group>"; };
+		21D6642316E78467008E0337 /* Base64TranscoderFHS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Base64TranscoderFHS.h; sourceTree = "<group>"; };
 		9B2A1B9815E805D1007E66E0 /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		9B2A1B9915E805D1007E66E0 /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
 		9B2A1B9B15E805D1007E66E0 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -43,8 +45,6 @@
 		9B2A1C0915E807D9007E66E0 /* FHSTwitterEngine.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FHSTwitterEngine.m; sourceTree = "<group>"; };
 		9B2A1C0E15E807D9007E66E0 /* NSString+URLEncoding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSString+URLEncoding.h"; sourceTree = "<group>"; };
 		9B2A1C0F15E807D9007E66E0 /* NSString+URLEncoding.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+URLEncoding.m"; sourceTree = "<group>"; };
-		9B2A1C1315E807D9007E66E0 /* Base64Transcoder.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = Base64Transcoder.c; sourceTree = "<group>"; };
-		9B2A1C1415E807D9007E66E0 /* Base64Transcoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Base64Transcoder.h; sourceTree = "<group>"; };
 		9B2A1C1515E807D9007E66E0 /* OAAsynchronousDataFetcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OAAsynchronousDataFetcher.h; sourceTree = "<group>"; };
 		9B2A1C1615E807D9007E66E0 /* OAAsynchronousDataFetcher.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OAAsynchronousDataFetcher.m; sourceTree = "<group>"; };
 		9B2A1C1715E807D9007E66E0 /* OAConsumer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OAConsumer.h; sourceTree = "<group>"; };
@@ -155,8 +155,8 @@
 		9B2A1C1215E807D9007E66E0 /* Crytpo */ = {
 			isa = PBXGroup;
 			children = (
-				9B2A1C1415E807D9007E66E0 /* Base64Transcoder.h */,
-				9B2A1C1315E807D9007E66E0 /* Base64Transcoder.c */,
+				21D6642216E78467008E0337 /* Base64TranscoderFHS.c */,
+				21D6642316E78467008E0337 /* Base64TranscoderFHS.h */,
 			);
 			path = Crytpo;
 			sourceTree = "<group>";
@@ -258,7 +258,6 @@
 				9B2A1BD715E805D1007E66E0 /* ViewController.m in Sources */,
 				9B2A1C2915E807D9007E66E0 /* FHSTwitterEngine.m in Sources */,
 				9B2A1C2B15E807D9007E66E0 /* NSString+URLEncoding.m in Sources */,
-				9B2A1C2D15E807D9007E66E0 /* Base64Transcoder.c in Sources */,
 				9B2A1C2E15E807D9007E66E0 /* OAAsynchronousDataFetcher.m in Sources */,
 				9B2A1C2F15E807D9007E66E0 /* OAConsumer.m in Sources */,
 				9B2A1C3115E807D9007E66E0 /* OAHMAC_SHA1SignatureProvider.m in Sources */,
@@ -266,6 +265,7 @@
 				9B2A1C3415E807D9007E66E0 /* OARequestParameter.m in Sources */,
 				9B2A1C3515E807D9007E66E0 /* OAServiceTicket.m in Sources */,
 				9B2A1C3615E807D9007E66E0 /* OAToken.m in Sources */,
+				21D6642416E78494008E0337 /* Base64TranscoderFHS.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/FHSTwitterEngine/FHSTwitterEngine.m
+++ b/FHSTwitterEngine/FHSTwitterEngine.m
@@ -2119,9 +2119,10 @@ id removeNull(id rootObject) {
                 return YES;
             }
         }
+        CFRelease(reachability);
     }
     
-    CFRelease(reachability);
+    
     return NO;
 }
 
@@ -2365,7 +2366,7 @@ static char encodingTable[64] = {
 		unsigned long ixtext = 0;
 		unsigned long lentext = 0;
 		unsigned char ch = 0;
-		unsigned char inbuf[4], outbuf[3];
+		unsigned char inbuf[4] = {0,0,0,0}, outbuf[3] = {0,0,0};
 		short ixinbuf = 0;
 		BOOL flignore = NO;
 		BOOL flendtext = NO;

--- a/FHSTwitterEngine/OAuthConsumer/OAConsumer.m
+++ b/FHSTwitterEngine/OAuthConsumer/OAConsumer.m
@@ -37,8 +37,8 @@
 }
 
 - (void)dealloc {
-	[self.key release];
-	[self.secret release];
+	self.key = nil;
+	self.secret = nil;
 	[super dealloc];
 }
 

--- a/FHSTwitterEngine/OAuthConsumer/OARequestParameter.m
+++ b/FHSTwitterEngine/OAuthConsumer/OARequestParameter.m
@@ -43,8 +43,8 @@
 }
 
 - (void)dealloc {
-	[self.name release];
-	[self.value release];
+	self.name = nil;
+	self.value = nil;
 	[super dealloc];
 }
 

--- a/FHSTwitterEngine/OAuthConsumer/OAServiceTicket.m
+++ b/FHSTwitterEngine/OAuthConsumer/OAServiceTicket.m
@@ -40,8 +40,8 @@
 }
 
 - (void)dealloc {
-	[self.request release];
-	[self.response release];
+	self.request = nil;
+	self.response = nil;
 	[super dealloc];
 }
 

--- a/FHSTwitterEngine/OAuthConsumer/OAToken.m
+++ b/FHSTwitterEngine/OAuthConsumer/OAToken.m
@@ -103,9 +103,9 @@
 }
 
 - (void)dealloc {
-	[self.verifier release];
-	[self.key release];
-	[self.secret release];
+	self.verifier = nil;
+	self.key = nil;
+	self.secret = nil;
 	[super dealloc];
 }
 


### PR DESCRIPTION
Changed files on Crypto folder. Now the project compile successfully.
Fixed potential leaks in dealloc for the followings files: OAConsumer, OARequestParameter, OAToken and OAServiceTicket.
Fixed null pointer argument in call to CFRelease (FHSTwitterEngine).
Remove warnings for uninitialized variables (inbuf[4], outbuf[3], in FHSTwitterEngine.
