### PR TITLE
Fixed bug that cause Swift demo app to crash on launch

### DIFF
--- a/FHSTwitterEngineDemoSwift/Demo-Swift/ViewController.swift
+++ b/FHSTwitterEngineDemoSwift/Demo-Swift/ViewController.swift
@@ -30,9 +30,7 @@ class ViewController: UITableViewController, FHSTwitterEngineAccessTokenDelegate
         
         FHSTwitterEngine.sharedEngine().permanentlySetConsumerKey("Xg3ACDprWAH8loEPjMzRg", andSecret: "9LwYDxw1iTc6D9ebHdrYCZrJP4lJhQv5uf4ueiPHvJ0")
         FHSTwitterEngine.sharedEngine().delegate = self
-        if loadAccessToken() != nil {
-            FHSTwitterEngine.sharedEngine().loadAccessToken()
-        }
+        FHSTwitterEngine.sharedEngine().loadAccessToken()
     }
     
     // MARK: - Private

--- a/FHSTwitterEngineDemoSwift/Demo-Swift/ViewController.swift
+++ b/FHSTwitterEngineDemoSwift/Demo-Swift/ViewController.swift
@@ -30,7 +30,9 @@ class ViewController: UITableViewController, FHSTwitterEngineAccessTokenDelegate
         
         FHSTwitterEngine.sharedEngine().permanentlySetConsumerKey("Xg3ACDprWAH8loEPjMzRg", andSecret: "9LwYDxw1iTc6D9ebHdrYCZrJP4lJhQv5uf4ueiPHvJ0")
         FHSTwitterEngine.sharedEngine().delegate = self
-        FHSTwitterEngine.sharedEngine().loadAccessToken()        
+        if loadAccessToken() != nil {
+            FHSTwitterEngine.sharedEngine().loadAccessToken()
+        }
     }
     
     // MARK: - Private
@@ -51,7 +53,7 @@ class ViewController: UITableViewController, FHSTwitterEngineAccessTokenDelegate
     }
     
     override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
-        var cell:UITableViewCell = tableView.dequeueReusableCellWithIdentifier(cellId, forIndexPath: indexPath) as UITableViewCell
+        let cell:UITableViewCell = tableView.dequeueReusableCellWithIdentifier(cellId, forIndexPath: indexPath) as UITableViewCell
         
         let action = self.dataSource[indexPath.row] as String
         
@@ -101,8 +103,11 @@ class ViewController: UITableViewController, FHSTwitterEngineAccessTokenDelegate
         NSUserDefaults.standardUserDefaults().setObject(accessToken, forKey: "SavedAccessHTTPBody")
     }
     
-    func loadAccessToken() -> String! {
-        return NSUserDefaults.standardUserDefaults().objectForKey("SavedAccessHTTPBody") as String
+    func loadAccessToken() -> String? {
+        if let outputStr = NSUserDefaults.standardUserDefaults().objectForKey("SavedAccessHTTPBody") as? String{
+            return outputStr
+        }
+        return nil
     }
 }
 


### PR DESCRIPTION
The swift demo app crashed on launch because it hadn't set any value to `"SavedAccessHTTPBody"`. I added a condition to make sure the key exist before unwrapping the value.